### PR TITLE
Updating main script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.DS_Store

--- a/data/who-regions.csv
+++ b/data/who-regions.csv
@@ -1,0 +1,195 @@
+Entity,Code,Year,WHO region
+Afghanistan,AFG,2017,Eastern Mediterranean
+Albania,ALB,2017,Europe
+Algeria,DZA,2017,Africa
+Andorra,AND,2017,Europe
+Angola,AGO,2017,Africa
+Antigua and Barbuda,ATG,2017,Americas
+Argentina,ARG,2017,Americas
+Armenia,ARM,2017,Europe
+Australia,AUS,2017,Western Pacific
+Austria,AUT,2017,Europe
+Azerbaijan,AZE,2017,Europe
+Bahamas,BHS,2017,Americas
+Bahrain,BHR,2017,Eastern Mediterranean
+Bangladesh,BGD,2017,South-East Asia
+Barbados,BRB,2017,Americas
+Belarus,BLR,2017,Europe
+Belgium,BEL,2017,Europe
+Belize,BLZ,2017,Americas
+Benin,BEN,2017,Africa
+Bhutan,BTN,2017,South-East Asia
+Bolivia,BOL,2017,Americas
+Bosnia and Herzegovina,BIH,2017,Europe
+Botswana,BWA,2017,Africa
+Brazil,BRA,2017,Americas
+Brunei,BRN,2017,Western Pacific
+Bulgaria,BGR,2017,Europe
+Burkina Faso,BFA,2017,Africa
+Burundi,BDI,2017,Africa
+Cambodia,KHM,2017,Western Pacific
+Cameroon,CMR,2017,Africa
+Canada,CAN,2017,Americas
+Cape Verde,CPV,2017,Africa
+Central African Republic,CAF,2017,Africa
+Chad,TCD,2017,Africa
+Chile,CHL,2017,Americas
+China,CHN,2017,Western Pacific
+Colombia,COL,2017,Americas
+Comoros,COM,2017,Africa
+Congo,COG,2017,Africa
+Cook Islands,COK,2017,Western Pacific
+Costa Rica,CRI,2017,Americas
+Cote d'Ivoire,CIV,2017,Africa
+Croatia,HRV,2017,Europe
+Cuba,CUB,2017,Americas
+Cyprus,CYP,2017,Europe
+Czechia,CZE,2017,Europe
+Democratic Republic of Congo,COD,2017,Africa
+Denmark,DNK,2017,Europe
+Djibouti,DJI,2017,Eastern Mediterranean
+Dominica,DMA,2017,Americas
+Dominican Republic,DOM,2017,Americas
+Ecuador,ECU,2017,Americas
+Egypt,EGY,2017,Eastern Mediterranean
+El Salvador,SLV,2017,Americas
+Equatorial Guinea,GNQ,2017,Africa
+Eritrea,ERI,2017,Africa
+Estonia,EST,2017,Europe
+Eswatini,SWZ,2017,Africa
+Ethiopia,ETH,2017,Africa
+Fiji,FJI,2017,Western Pacific
+Finland,FIN,2017,Europe
+France,FRA,2017,Europe
+Gabon,GAB,2017,Africa
+Gambia,GMB,2017,Africa
+Georgia,GEO,2017,Europe
+Germany,DEU,2017,Europe
+Ghana,GHA,2017,Africa
+Greece,GRC,2017,Europe
+Grenada,GRD,2017,Americas
+Guatemala,GTM,2017,Americas
+Guinea,GIN,2017,Africa
+Guinea-Bissau,GNB,2017,Africa
+Guyana,GUY,2017,Americas
+Haiti,HTI,2017,Americas
+Honduras,HND,2017,Americas
+Hungary,HUN,2017,Europe
+Iceland,ISL,2017,Europe
+India,IND,2017,South-East Asia
+Indonesia,IDN,2017,South-East Asia
+Iran,IRN,2017,Eastern Mediterranean
+Iraq,IRQ,2017,Eastern Mediterranean
+Ireland,IRL,2017,Europe
+Israel,ISR,2017,Europe
+Italy,ITA,2017,Europe
+Jamaica,JAM,2017,Americas
+Japan,JPN,2017,Western Pacific
+Jordan,JOR,2017,Eastern Mediterranean
+Kazakhstan,KAZ,2017,Europe
+Kenya,KEN,2017,Africa
+Kiribati,KIR,2017,Western Pacific
+Kuwait,KWT,2017,Eastern Mediterranean
+Kyrgyzstan,KGZ,2017,Europe
+Laos,LAO,2017,Western Pacific
+Latvia,LVA,2017,Europe
+Lebanon,LBN,2017,Eastern Mediterranean
+Lesotho,LSO,2017,Africa
+Liberia,LBR,2017,Africa
+Libya,LBY,2017,Eastern Mediterranean
+Lithuania,LTU,2017,Europe
+Luxembourg,LUX,2017,Europe
+Madagascar,MDG,2017,Africa
+Malawi,MWI,2017,Africa
+Malaysia,MYS,2017,Western Pacific
+Maldives,MDV,2017,South-East Asia
+Mali,MLI,2017,Africa
+Malta,MLT,2017,Europe
+Marshall Islands,MHL,2017,Western Pacific
+Mauritania,MRT,2017,Africa
+Mauritius,MUS,2017,Africa
+Mexico,MEX,2017,Americas
+Micronesia (country),FSM,2017,Western Pacific
+Moldova,MDA,2017,Europe
+Monaco,MCO,2017,Europe
+Mongolia,MNG,2017,Western Pacific
+Montenegro,MNE,2017,Europe
+Morocco,MAR,2017,Eastern Mediterranean
+Mozambique,MOZ,2017,Africa
+Myanmar,MMR,2017,South-East Asia
+Namibia,NAM,2017,Africa
+Nauru,NRU,2017,Western Pacific
+Nepal,NPL,2017,South-East Asia
+Netherlands,NLD,2017,Europe
+New Zealand,NZL,2017,Western Pacific
+Nicaragua,NIC,2017,Americas
+Niger,NER,2017,Africa
+Nigeria,NGA,2017,Africa
+Niue,NIU,2017,Western Pacific
+North Korea,PRK,2017,South-East Asia
+North Macedonia,MKD,2017,Europe
+Norway,NOR,2017,Europe
+Oman,OMN,2017,Eastern Mediterranean
+Pakistan,PAK,2017,Eastern Mediterranean
+Palau,PLW,2017,Western Pacific
+Panama,PAN,2017,Americas
+Papua New Guinea,PNG,2017,Western Pacific
+Paraguay,PRY,2017,Americas
+Peru,PER,2017,Americas
+Philippines,PHL,2017,Western Pacific
+Poland,POL,2017,Europe
+Portugal,PRT,2017,Europe
+Qatar,QAT,2017,Eastern Mediterranean
+Romania,ROU,2017,Europe
+Russia,RUS,2017,Europe
+Rwanda,RWA,2017,Africa
+Saint Kitts and Nevis,KNA,2017,Americas
+Saint Lucia,LCA,2017,Americas
+Saint Vincent and the Grenadines,VCT,2017,Americas
+Samoa,WSM,2017,Western Pacific
+San Marino,SMR,2017,Europe
+Sao Tome and Principe,STP,2017,Africa
+Saudi Arabia,SAU,2017,Eastern Mediterranean
+Senegal,SEN,2017,Africa
+Serbia,SRB,2017,Europe
+Seychelles,SYC,2017,Africa
+Sierra Leone,SLE,2017,Africa
+Singapore,SGP,2017,Western Pacific
+Slovakia,SVK,2017,Europe
+Slovenia,SVN,2017,Europe
+Solomon Islands,SLB,2017,Western Pacific
+Somalia,SOM,2017,Eastern Mediterranean
+South Africa,ZAF,2017,Africa
+South Korea,KOR,2017,Western Pacific
+South Sudan,SSD,2017,Africa
+Spain,ESP,2017,Europe
+Sri Lanka,LKA,2017,South-East Asia
+Sudan,SDN,2017,Eastern Mediterranean
+Suriname,SUR,2017,Americas
+Sweden,SWE,2017,Europe
+Switzerland,CHE,2017,Europe
+Syria,SYR,2017,Eastern Mediterranean
+Tajikistan,TJK,2017,Europe
+Tanzania,TZA,2017,Africa
+Thailand,THA,2017,South-East Asia
+Timor,TLS,2017,South-East Asia
+Togo,TGO,2017,Africa
+Tonga,TON,2017,Western Pacific
+Trinidad and Tobago,TTO,2017,Americas
+Tunisia,TUN,2017,Eastern Mediterranean
+Turkey,TUR,2017,Europe
+Turkmenistan,TKM,2017,Europe
+Tuvalu,TUV,2017,Western Pacific
+Uganda,UGA,2017,Africa
+Ukraine,UKR,2017,Europe
+United Arab Emirates,ARE,2017,Eastern Mediterranean
+United Kingdom,GBR,2017,Europe
+United States,USA,2017,Americas
+Uruguay,URY,2017,Americas
+Uzbekistan,UZB,2017,Europe
+Vanuatu,VUT,2017,Western Pacific
+Venezuela,VEN,2017,Americas
+Vietnam,VNM,2017,Western Pacific
+Yemen,YEM,2017,Eastern Mediterranean
+Zambia,ZMB,2017,Africa
+Zimbabwe,ZWE,2017,Africa

--- a/scripts/merge-gisaid-owid.py
+++ b/scripts/merge-gisaid-owid.py
@@ -236,6 +236,14 @@ def pivot_merged_df(merged_df):
 def add_regions(merged_df, region_path='data/who-regions.csv'):
     who_regions = pd.read_csv(region_path)
     merged_df = pd.merge(merged_df, who_regions[['Entity','WHO region']], how='left', left_on=['owid_location'], right_on=['Entity'])
+    merged_df.rename(columns={'WHO region': 'who_region'}, inplace=True)
+    merged_df.drop('Entity', axis=1, inplace=True)
+    return merged_df
+
+def cleanup_columns(merged_df):
+    # prepend gisaid_ to respective columns except for the lineage ones
+    renamed_cols = {c:'gisaid_'+c for c in merged_df.columns if ('collect' in c) or ('country' in c)}
+    merged_df.rename(columns=renamed_cols, inplace=True)
     return merged_df
 
 def main(args_list=None):
@@ -261,6 +269,8 @@ def main(args_list=None):
     merged_pivoted_df = pivot_merged_df(merged_df)
     print('Add WHO regions to countries...')
     merged_pivoted_df = add_regions(merged_pivoted_df)
+    print('Final data file cleanup...')
+    merged_pivoted_df = cleanup_columns(merged_pivoted_df)
     print('Done.')
 
     max_gisaid_date = gisaid_df.submit_date.max()


### PR DESCRIPTION
- [x] fixed merging with placeholder column in order to include all dates in timeseries (past collect_date)
- [x] fixed bug where more rows of OWID cases were being included due to unique country-region combo (i.e. United States-Oceania)
- [x] changed USA --> United States for merging with OWID location
- [x] changed Czech Republic --> Czechia for merging with OWID location
- [x] timeseries starts 2020-01-01 (first date of OWID data), ends on max GISAID submit_date
- [x] added WHO regions
- [x] fixed gaps in lineage totals and population data not being merged in
- [x] updated to latest metadata export on 2021-05-11
- [x] rearrange/rename output CSV columns for convenience --> the gisaid columns (except the individual lineage ones) now have "gisaid_" prepended
- [x] USA has 2 less total sequence count in output than the GISAID filtered df, need to track down why --> UPDATE: this was because those 2 sequences predated the beginning of the OWID timeseries for USA, the corresponding owid_date for those sequences was NaT, and it got dropped when filtering by owid_date as a result. Fixed this by copying over collect_date where owid_date is NaT
- [x] sequences from these countries did not get merged in and were dropped because of country spelling differences from OWID data --> UPDATE: sequences from these locations are now included as extra rows per date, which can sometimes look repetitive (i.e. "Morocco" and "morocco" being separate rows) but this shouldn't affect any roll-ups because there isn't any duplication of sequences or case numbers. 

TODO in a follow-up PR to clean-up these gisaid country names:
```
Bonaire
British Virgin Islands
Crimea
Democratic Republic of the Congo
Faroe Islands
French Guiana
Guadeloupe
Guam
Guyane
Kosovo
Martinique
Mayotte
Northern Mariana Islands
Republic of Congo
Republic of the Congo
Reunion
Saint Barthelemy
Saint Martin
Sint Eustatius
Sint Maarten
Timor-Leste
mongolia
morocco
```